### PR TITLE
fix: highlight correct territory after 3 mistakes instead of next rou…

### DIFF
--- a/src/components/MapGame.vue
+++ b/src/components/MapGame.vue
@@ -221,6 +221,8 @@
     if (clickedEntityName === targetEntity.value) {
       handleCorrectGuess(clickedEntityName);
     } else {
+      // Capture the current target before it changes
+      const currentTarget = targetEntity.value;
       const { shouldEndRound } = handleIncorrectGuess();
       if (!shouldEndRound) {
         // Temporarily highlight the incorrectly clicked layer
@@ -235,7 +237,7 @@
         }, 1000);
       } else {
         // Round ended due to too many attempts, highlight the correct one
-        highlightTargetEntity(targetEntity.value);
+        highlightTargetEntity(currentTarget);
       }
     }
   };
@@ -264,11 +266,13 @@
     if (name === targetEntity.value) {
       handleCorrectGuess(name);
     } else {
+      // Capture the current target before it changes
+      const currentTarget = targetEntity.value;
       const { shouldEndRound } = handleIncorrectGuess();
       if (shouldEndRound) {
         // Round ended due to too many attempts, highlight the correct one
         // (Highlighting might target a polygon even if a marker was clicked)
-        highlightTargetEntity(targetEntity.value);
+        highlightTargetEntity(currentTarget);
       }
       // No temporary highlight logic for markers was present, so none added here
     }


### PR DESCRIPTION
…nd's target

Fixed bug where after making 3 mistakes, the game would highlight the next round's target territory instead of the current round's correct answer. The issue was that handleIncorrectGuess() advances the round and changes targetEntity.value before highlightTargetEntity() is called.