### PR TITLE
MOD-1.3: Extract coordinate transformation utilities

### DIFF
--- a/src/components/AdministrativeDivisions/FrenchDepartments.vue
+++ b/src/components/AdministrativeDivisions/FrenchDepartments.vue
@@ -68,6 +68,7 @@ import MapGame from "../MapGame.vue";
 import { getStyleForAttempts } from "../../utils/geojsonUtils";
 import type { FeatureCollection, Geometry } from 'geojson';
 import type { GeoJSONProperties } from "../../utils/geojsonUtils";
+import { shiftCoordinatesLegacy as shiftCoordinates } from "../../utils/geo/coordinateTransforms";
 
 const mapOptions = {
   initialCenter: [46.603354, 1.888334] as L.LatLngExpression,
@@ -137,43 +138,6 @@ const processGeojsonData = (data: FeatureCollection<Geometry, GeoJSONProperties>
 
   return wrappedCollection;
 };
-
-// Shift coordinates by the specified offset
-function shiftCoordinates(feature: any, offset: number) {
-  if (!feature.geometry) return feature;
-
-  const shiftPoint = (coords: number[]) => {
-    const x = coords[0];
-    const y = coords[1];
-    if (x === undefined || y === undefined) {
-      throw new Error("Invalid coordinates");
-    }
-    return [x + offset, y];
-  };
-
-  switch (feature.geometry.type) {
-    case 'Point':
-      feature.geometry.coordinates = shiftPoint(feature.geometry.coordinates);
-      break;
-    case 'LineString':
-    case 'MultiPoint':
-      feature.geometry.coordinates = feature.geometry.coordinates.map(shiftPoint);
-      break;
-    case 'Polygon':
-    case 'MultiLineString':
-      feature.geometry.coordinates = feature.geometry.coordinates.map((ring: number[][]) =>
-        ring.map(shiftPoint)
-      );
-      break;
-    case 'MultiPolygon':
-      feature.geometry.coordinates = feature.geometry.coordinates.map((polygon: number[][][]) =>
-        polygon.map((ring: number[][]) => ring.map(shiftPoint))
-      );
-      break;
-  }
-
-  return feature;
-}
 
 interface Territory {
   name: string;

--- a/src/components/WorldCountries/WorldCountries.vue
+++ b/src/components/WorldCountries/WorldCountries.vue
@@ -15,6 +15,7 @@ import MapGame from '../MapGame.vue';
 import L from 'leaflet';
 import type { FeatureCollection, Geometry } from 'geojson';
 import type { GeoJSONProperties } from "../../utils/geojsonUtils";
+import { shiftCoordinatesLegacy as shiftCoordinates } from "../../utils/geo/coordinateTransforms";
 
 const mapOptions = {
   initialCenter: [20, 0] as L.LatLngExpression,
@@ -55,40 +56,4 @@ const processGeojsonData = (data: FeatureCollection<Geometry, GeoJSONProperties>
 
   return wrappedCollection;
 };
-
-function shiftCoordinates(feature: any, offset: number) {
-  if (!feature.geometry) return feature;
-
-  const shiftPoint = (coords: number[]) => {
-    const x = coords[0];
-    const y = coords[1];
-    if (x === undefined || y === undefined) {
-      throw new Error("Invalid coordinates");
-    }
-    return [x + offset, y];
-  };
-
-  switch (feature.geometry.type) {
-    case 'Point':
-      feature.geometry.coordinates = shiftPoint(feature.geometry.coordinates);
-      break;
-    case 'LineString':
-    case 'MultiPoint':
-      feature.geometry.coordinates = feature.geometry.coordinates.map(shiftPoint);
-      break;
-    case 'Polygon':
-    case 'MultiLineString':
-      feature.geometry.coordinates = feature.geometry.coordinates.map((ring: number[][]) =>
-        ring.map(shiftPoint)
-      );
-      break;
-    case 'MultiPolygon':
-      feature.geometry.coordinates = feature.geometry.coordinates.map((polygon: number[][][]) =>
-        polygon.map((ring: number[][]) => ring.map(shiftPoint))
-      );
-      break;
-  }
-
-  return feature;
-}
 </script>

--- a/src/utils/geo/coordinateTransforms.spec.ts
+++ b/src/utils/geo/coordinateTransforms.spec.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest'
+import type { Feature, Geometry, Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon } from 'geojson'
+import {
+  shiftCoordinate,
+  shiftCoordinates,
+  shiftGeometryCoordinates,
+  shiftFeatureCoordinates,
+} from './coordinateTransforms'
+
+describe('coordinateTransforms', () => {
+  describe('shiftCoordinate', () => {
+    it('should shift a 2D coordinate by the specified offset', () => {
+      const coord = [10, 20] as [number, number]
+      const result = shiftCoordinate(coord, 5)
+      expect(result).toEqual([15, 20])
+    })
+
+    it('should shift a 3D coordinate and preserve Z value', () => {
+      const coord = [10, 20, 100] as [number, number, number]
+      const result = shiftCoordinate(coord, 5)
+      expect(result).toEqual([15, 20, 100])
+    })
+
+    it('should throw error for invalid coordinate', () => {
+      const coord = [10] as unknown as [number, number]
+      expect(() => shiftCoordinate(coord, 5)).toThrow('Invalid coordinate')
+    })
+
+    it('should handle negative offsets', () => {
+      const coord = [10, 20] as [number, number]
+      const result = shiftCoordinate(coord, -15)
+      expect(result).toEqual([-5, 20])
+    })
+  })
+
+  describe('shiftCoordinates', () => {
+    it('should shift an array of coordinates', () => {
+      const coords: [number, number][] = [
+        [0, 0],
+        [10, 10],
+        [20, 20],
+      ]
+      const result = shiftCoordinates(coords, 100)
+      expect(result).toEqual([
+        [100, 0],
+        [110, 10],
+        [120, 20],
+      ])
+    })
+
+    it('should handle empty array', () => {
+      const result = shiftCoordinates([], 5)
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('shiftGeometryCoordinates', () => {
+    it('should shift Point geometry', () => {
+      const geometry: Point = {
+        type: 'Point',
+        coordinates: [10, 20],
+      }
+      shiftGeometryCoordinates(geometry, 5)
+      expect(geometry.coordinates).toEqual([15, 20])
+    })
+
+    it('should shift LineString geometry', () => {
+      const geometry: LineString = {
+        type: 'LineString',
+        coordinates: [
+          [0, 0],
+          [10, 10],
+        ],
+      }
+      shiftGeometryCoordinates(geometry, 100)
+      expect(geometry.coordinates).toEqual([
+        [100, 0],
+        [110, 10],
+      ])
+    })
+
+    it('should shift Polygon geometry', () => {
+      const geometry: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [10, 0],
+            [10, 10],
+            [0, 10],
+            [0, 0],
+          ],
+        ],
+      }
+      shiftGeometryCoordinates(geometry, 50)
+      expect(geometry.coordinates).toEqual([
+        [
+          [50, 0],
+          [60, 0],
+          [60, 10],
+          [50, 10],
+          [50, 0],
+        ],
+      ])
+    })
+
+    it('should shift MultiPoint geometry', () => {
+      const geometry: MultiPoint = {
+        type: 'MultiPoint',
+        coordinates: [
+          [0, 0],
+          [10, 10],
+        ],
+      }
+      shiftGeometryCoordinates(geometry, 5)
+      expect(geometry.coordinates).toEqual([
+        [5, 0],
+        [15, 10],
+      ])
+    })
+
+    it('should shift MultiLineString geometry', () => {
+      const geometry: MultiLineString = {
+        type: 'MultiLineString',
+        coordinates: [
+          [
+            [0, 0],
+            [10, 10],
+          ],
+          [
+            [20, 20],
+            [30, 30],
+          ],
+        ],
+      }
+      shiftGeometryCoordinates(geometry, 100)
+      expect(geometry.coordinates).toEqual([
+        [
+          [100, 0],
+          [110, 10],
+        ],
+        [
+          [120, 20],
+          [130, 30],
+        ],
+      ])
+    })
+
+    it('should shift MultiPolygon geometry', () => {
+      const geometry: MultiPolygon = {
+        type: 'MultiPolygon',
+        coordinates: [
+          [
+            [
+              [0, 0],
+              [10, 0],
+              [10, 10],
+              [0, 0],
+            ],
+          ],
+          [
+            [
+              [20, 20],
+              [30, 20],
+              [30, 30],
+              [20, 20],
+            ],
+          ],
+        ],
+      }
+      shiftGeometryCoordinates(geometry, -10)
+      expect(geometry.coordinates).toEqual([
+        [
+          [
+            [-10, 0],
+            [0, 0],
+            [0, 10],
+            [-10, 0],
+          ],
+        ],
+        [
+          [
+            [10, 20],
+            [20, 20],
+            [20, 30],
+            [10, 20],
+          ],
+        ],
+      ])
+    })
+  })
+
+  describe('shiftFeatureCoordinates', () => {
+    it('should return a new feature without mutating the original', () => {
+      const feature: Feature<Point> = {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [10, 20],
+        },
+        properties: { name: 'Test Point' },
+      }
+
+      const shifted = shiftFeatureCoordinates(feature, 5)
+
+      // Original should be unchanged
+      expect(feature.geometry.coordinates).toEqual([10, 20])
+      // New feature should be shifted
+      expect(shifted.geometry?.coordinates).toEqual([15, 20])
+      // Properties should be preserved
+      expect(shifted.properties).toEqual({ name: 'Test Point' })
+    })
+
+    it('should handle feature without geometry', () => {
+      const feature: Feature<Geometry> = {
+        type: 'Feature',
+        geometry: null as any,
+        properties: { name: 'Test' },
+      }
+
+      const shifted = shiftFeatureCoordinates(feature, 5)
+      expect(shifted.geometry).toBeNull()
+      expect(shifted.properties).toEqual({ name: 'Test' })
+    })
+
+    it('should shift Polygon feature correctly', () => {
+      const feature: Feature<Polygon> = {
+        type: 'Feature',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [0, 0],
+              [10, 0],
+              [10, 10],
+              [0, 10],
+              [0, 0],
+            ],
+          ],
+        },
+        properties: {},
+      }
+
+      const shifted = shiftFeatureCoordinates(feature, 360)
+      expect(shifted.geometry.coordinates).toEqual([
+        [
+          [360, 0],
+          [370, 0],
+          [370, 10],
+          [360, 10],
+          [360, 0],
+        ],
+      ])
+    })
+  })
+})

--- a/src/utils/geo/coordinateTransforms.ts
+++ b/src/utils/geo/coordinateTransforms.ts
@@ -1,0 +1,110 @@
+import type { Feature, Geometry, Position } from 'geojson'
+
+/**
+ * Shifts a coordinate point by the specified offset
+ */
+export function shiftCoordinate(coord: Position, offset: number): Position {
+  const x = coord[0]
+  const y = coord[1]
+  if (x === undefined || y === undefined) {
+    throw new Error('Invalid coordinate: missing x or y value')
+  }
+  return [x + offset, y, ...(coord.slice(2) as number[])]
+}
+
+/**
+ * Shifts an array of coordinates by the specified offset
+ */
+export function shiftCoordinates(coords: Position[], offset: number): Position[] {
+  return coords.map((coord) => shiftCoordinate(coord, offset))
+}
+
+/**
+ * Shifts a geometry's coordinates by the specified offset
+ */
+export function shiftGeometryCoordinates(geometry: Geometry, offset: number): void {
+  switch (geometry.type) {
+    case 'Point':
+      geometry.coordinates = shiftCoordinate(geometry.coordinates as Position, offset)
+      break
+
+    case 'LineString':
+    case 'MultiPoint':
+      geometry.coordinates = shiftCoordinates(geometry.coordinates as Position[], offset)
+      break
+
+    case 'Polygon':
+    case 'MultiLineString':
+      geometry.coordinates = (geometry.coordinates as Position[][]).map((ring) =>
+        shiftCoordinates(ring, offset)
+      )
+      break
+
+    case 'MultiPolygon':
+      geometry.coordinates = (geometry.coordinates as Position[][][]).map((polygon) =>
+        polygon.map((ring) => shiftCoordinates(ring, offset))
+      )
+      break
+
+    case 'GeometryCollection':
+      geometry.geometries.forEach((geom) => shiftGeometryCoordinates(geom, offset))
+      break
+  }
+}
+
+/**
+ * Shifts a GeoJSON feature's coordinates by the specified offset
+ * Returns a new feature with shifted coordinates (does not mutate the original)
+ */
+export function shiftFeatureCoordinates<G extends Geometry = Geometry>(
+  feature: Feature<G>,
+  offset: number
+): Feature<G> {
+  const clonedFeature = structuredClone(feature)
+  if (!clonedFeature.geometry) {
+    return clonedFeature
+  }
+  shiftGeometryCoordinates(clonedFeature.geometry, offset)
+  return clonedFeature
+}
+
+/**
+ * Legacy function for backward compatibility
+ * Mutates the feature in place
+ * @deprecated Use shiftFeatureCoordinates instead
+ */
+export function shiftCoordinatesLegacy(feature: any, offset: number): any {
+  if (!feature.geometry) return feature
+
+  const shiftPoint = (coords: number[]) => {
+    const x = coords[0]
+    const y = coords[1]
+    if (x === undefined || y === undefined) {
+      throw new Error('Invalid coordinates')
+    }
+    return [x + offset, y]
+  }
+
+  switch (feature.geometry.type) {
+    case 'Point':
+      feature.geometry.coordinates = shiftPoint(feature.geometry.coordinates)
+      break
+    case 'LineString':
+    case 'MultiPoint':
+      feature.geometry.coordinates = feature.geometry.coordinates.map(shiftPoint)
+      break
+    case 'Polygon':
+    case 'MultiLineString':
+      feature.geometry.coordinates = feature.geometry.coordinates.map((coords: any) =>
+        coords.map(shiftPoint)
+      )
+      break
+    case 'MultiPolygon':
+      feature.geometry.coordinates = feature.geometry.coordinates.map((polygon: any) =>
+        polygon.map((coords: any) => coords.map(shiftPoint))
+      )
+      break
+  }
+
+  return feature
+}


### PR DESCRIPTION
## Summary
This PR extracts duplicated coordinate transformation logic into a centralized utility module, eliminating code duplication and establishing a foundation for geographic utilities.

**Changes:**
- Created `src/utils/geo/coordinateTransforms.ts` with comprehensive coordinate transformation functions:
  - `shiftCoordinate()`: Shifts a single coordinate by an offset
  - `shiftCoordinates()`: Shifts an array of coordinates
  - `shiftGeometryCoordinates()`: Shifts geometry coordinates (supports all GeoJSON types)
  - `shiftFeatureCoordinates()`: Returns a new feature with shifted coordinates (immutable)
  - `shiftCoordinatesLegacy()`: Backward-compatible function for in-place mutation

- Added comprehensive test suite with 15 tests covering:
  - 2D and 3D coordinate shifting
  - All GeoJSON geometry types (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon)
  - Edge cases (empty arrays, null geometries)
  - Immutability verification

**Code Reduction:**
- Removed ~70 lines of duplicated code from:
  - `FrenchDepartments.vue`: Removed local shiftCoordinates function
  - `WorldCountries.vue`: Removed local shiftCoordinates function

**Verification:**
```bash
bun run test         # All 33 tests passing
bun run type-check   # Type checking passes
```

**Benefits:**
- Single source of truth for coordinate transformations
- Comprehensive test coverage for geographic utilities
- Type-safe coordinate manipulation
- Easier to maintain and extend

**Related Issue:**
Part of #32 - Geography Game Modernization Plan (Phase 1, PR 3/7)