### PR TITLE
MOD-1.4: Extract world wrapping logic

### DIFF
--- a/src/components/AdministrativeDivisions/FrenchDepartments.vue
+++ b/src/components/AdministrativeDivisions/FrenchDepartments.vue
@@ -68,7 +68,7 @@ import MapGame from "../MapGame.vue";
 import { getStyleForAttempts } from "../../utils/geojsonUtils";
 import type { FeatureCollection, Geometry } from 'geojson';
 import type { GeoJSONProperties } from "../../utils/geojsonUtils";
-import { shiftCoordinatesLegacy as shiftCoordinates } from "../../utils/geo/coordinateTransforms";
+import { createWorldWrappedCollection } from "../../utils/geo/worldWrapping";
 
 const mapOptions = {
   initialCenter: [46.603354, 1.888334] as L.LatLngExpression,
@@ -109,34 +109,7 @@ const navigateTo = (mapInstance: L.Map | null, region: string) => {
 
 // Process GeoJSON data to create east and west copies
 const processGeojsonData = (data: FeatureCollection<Geometry, GeoJSONProperties>) => {
-  const wrappedCollection = structuredClone(data);
-  const originalFeatures = data.features;
-
-  const eastFeatures = originalFeatures.map(feature => {
-    const clone = structuredClone(feature);
-    if (!clone.properties) clone.properties = {name: ""};
-    clone.properties.isEastCopy = true;
-
-    shiftCoordinates(clone, 360);
-    return clone;
-  });
-
-  const westFeatures = originalFeatures.map(feature => {
-    const clone = structuredClone(feature);
-    if (!clone.properties) clone.properties = {name: ""};
-    clone.properties.isWestCopy = true;
-
-    shiftCoordinates(clone, -360);
-    return clone;
-  });
-
-  wrappedCollection.features = [
-    ...originalFeatures,
-    ...eastFeatures,
-    ...westFeatures
-  ];
-
-  return wrappedCollection;
+  return createWorldWrappedCollection(data);
 };
 
 interface Territory {

--- a/src/components/WorldCountries/WorldCountries.vue
+++ b/src/components/WorldCountries/WorldCountries.vue
@@ -15,7 +15,7 @@ import MapGame from '../MapGame.vue';
 import L from 'leaflet';
 import type { FeatureCollection, Geometry } from 'geojson';
 import type { GeoJSONProperties } from "../../utils/geojsonUtils";
-import { shiftCoordinatesLegacy as shiftCoordinates } from "../../utils/geo/coordinateTransforms";
+import { createWorldWrappedCollection } from "../../utils/geo/worldWrapping";
 
 const mapOptions = {
   initialCenter: [20, 0] as L.LatLngExpression,
@@ -27,33 +27,6 @@ const mapOptions = {
 };
 
 const processGeojsonData = (data: FeatureCollection<Geometry, GeoJSONProperties>) => {
-  const wrappedCollection = structuredClone(data);
-  const originalFeatures = data.features;
-
-  const eastFeatures = originalFeatures.map(feature => {
-    const clone = structuredClone(feature);
-    if (!clone.properties) clone.properties = {name: ""};
-    clone.properties.isEastCopy = true;
-
-    shiftCoordinates(clone, 360);
-    return clone;
-  });
-
-  const westFeatures = originalFeatures.map(feature => {
-    const clone = structuredClone(feature);
-    if (!clone.properties) clone.properties = {name: ""};
-    clone.properties.isWestCopy = true;
-
-    shiftCoordinates(clone, -360);
-    return clone;
-  });
-
-  wrappedCollection.features = [
-    ...originalFeatures,
-    ...eastFeatures,
-    ...westFeatures
-  ];
-
-  return wrappedCollection;
+  return createWorldWrappedCollection(data);
 };
 </script>

--- a/src/utils/geo/worldWrapping.spec.ts
+++ b/src/utils/geo/worldWrapping.spec.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest'
+import type { FeatureCollection, Point, Polygon } from 'geojson'
+import { createWorldWrappedCollection } from './worldWrapping'
+
+describe('worldWrapping', () => {
+  describe('createWorldWrappedCollection', () => {
+    it('should create east and west copies of features', () => {
+      const originalCollection: FeatureCollection<Point> = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [0, 0],
+            },
+            properties: { name: 'Origin' },
+          },
+        ],
+      }
+
+      const wrapped = createWorldWrappedCollection(originalCollection)
+
+      // Should have 3 features: original + east copy + west copy
+      expect(wrapped.features).toHaveLength(3)
+
+      // Original feature should be unchanged
+      expect(wrapped.features[0]?.geometry.coordinates).toEqual([0, 0])
+      expect(wrapped.features[0]?.properties?.isEastCopy).toBeUndefined()
+      expect(wrapped.features[0]?.properties?.isWestCopy).toBeUndefined()
+
+      // East copy should be shifted +360
+      expect(wrapped.features[1]?.geometry.coordinates).toEqual([360, 0])
+      expect(wrapped.features[1]?.properties?.isEastCopy).toBe(true)
+
+      // West copy should be shifted -360
+      expect(wrapped.features[2]?.geometry.coordinates).toEqual([-360, 0])
+      expect(wrapped.features[2]?.properties?.isWestCopy).toBe(true)
+    })
+
+    it('should not mutate the original collection', () => {
+      const originalCollection: FeatureCollection<Point> = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [10, 20],
+            },
+            properties: { name: 'Test' },
+          },
+        ],
+      }
+
+      const originalCopy = structuredClone(originalCollection)
+      const wrapped = createWorldWrappedCollection(originalCollection)
+
+      // Original should be unchanged
+      expect(originalCollection).toEqual(originalCopy)
+      expect(originalCollection.features).toHaveLength(1)
+
+      // Wrapped should have 3 features
+      expect(wrapped.features).toHaveLength(3)
+    })
+
+    it('should handle multiple features', () => {
+      const originalCollection: FeatureCollection<Point> = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [0, 0] },
+            properties: { name: 'A' },
+          },
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [10, 10] },
+            properties: { name: 'B' },
+          },
+        ],
+      }
+
+      const wrapped = createWorldWrappedCollection(originalCollection)
+
+      // Should have 6 features (2 originals + 2 east + 2 west)
+      expect(wrapped.features).toHaveLength(6)
+
+      // Check ordering: originals first, then east copies, then west copies
+      expect(wrapped.features[0]?.properties?.name).toBe('A')
+      expect(wrapped.features[0]?.properties?.isEastCopy).toBeUndefined()
+
+      expect(wrapped.features[1]?.properties?.name).toBe('B')
+      expect(wrapped.features[1]?.properties?.isEastCopy).toBeUndefined()
+
+      expect(wrapped.features[2]?.properties?.name).toBe('A')
+      expect(wrapped.features[2]?.properties?.isEastCopy).toBe(true)
+
+      expect(wrapped.features[3]?.properties?.name).toBe('B')
+      expect(wrapped.features[3]?.properties?.isEastCopy).toBe(true)
+
+      expect(wrapped.features[4]?.properties?.name).toBe('A')
+      expect(wrapped.features[4]?.properties?.isWestCopy).toBe(true)
+
+      expect(wrapped.features[5]?.properties?.name).toBe('B')
+      expect(wrapped.features[5]?.properties?.isWestCopy).toBe(true)
+    })
+
+    it('should handle Polygon features', () => {
+      const originalCollection: FeatureCollection<Polygon> = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [0, 0],
+                  [10, 0],
+                  [10, 10],
+                  [0, 10],
+                  [0, 0],
+                ],
+              ],
+            },
+            properties: { name: 'Square' },
+          },
+        ],
+      }
+
+      const wrapped = createWorldWrappedCollection(originalCollection)
+
+      expect(wrapped.features).toHaveLength(3)
+
+      // Check east copy polygon coordinates
+      const eastCopy = wrapped.features[1]
+      if (eastCopy?.geometry.type === 'Polygon') {
+        expect(eastCopy.geometry.coordinates[0]?.[0]).toEqual([360, 0])
+        expect(eastCopy.geometry.coordinates[0]?.[1]).toEqual([370, 0])
+      }
+
+      // Check west copy polygon coordinates
+      const westCopy = wrapped.features[2]
+      if (westCopy?.geometry.type === 'Polygon') {
+        expect(westCopy.geometry.coordinates[0]?.[0]).toEqual([-360, 0])
+        expect(westCopy.geometry.coordinates[0]?.[1]).toEqual([-350, 0])
+      }
+    })
+
+    it('should not mark copies when markCopies option is false', () => {
+      const originalCollection: FeatureCollection<Point> = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [0, 0] },
+            properties: { name: 'Test' },
+          },
+        ],
+      }
+
+      const wrapped = createWorldWrappedCollection(originalCollection, { markCopies: false })
+
+      expect(wrapped.features).toHaveLength(3)
+
+      // None of the features should have isEastCopy or isWestCopy
+      expect(wrapped.features[0]?.properties?.isEastCopy).toBeUndefined()
+      expect(wrapped.features[0]?.properties?.isWestCopy).toBeUndefined()
+
+      expect(wrapped.features[1]?.properties?.isEastCopy).toBeUndefined()
+      expect(wrapped.features[1]?.properties?.isWestCopy).toBeUndefined()
+
+      expect(wrapped.features[2]?.properties?.isEastCopy).toBeUndefined()
+      expect(wrapped.features[2]?.properties?.isWestCopy).toBeUndefined()
+
+      // But coordinates should still be shifted
+      expect(wrapped.features[1]?.geometry.coordinates).toEqual([360, 0])
+      expect(wrapped.features[2]?.geometry.coordinates).toEqual([-360, 0])
+    })
+
+    it('should preserve other properties on copied features', () => {
+      const originalCollection: FeatureCollection<Point> = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [0, 0] },
+            properties: {
+              name: 'Test',
+              population: 1000000,
+              capital: true,
+            },
+          },
+        ],
+      }
+
+      const wrapped = createWorldWrappedCollection(originalCollection)
+
+      // East copy should preserve all properties
+      expect(wrapped.features[1]?.properties?.name).toBe('Test')
+      expect(wrapped.features[1]?.properties?.population).toBe(1000000)
+      expect(wrapped.features[1]?.properties?.capital).toBe(true)
+      expect(wrapped.features[1]?.properties?.isEastCopy).toBe(true)
+
+      // West copy should preserve all properties
+      expect(wrapped.features[2]?.properties?.name).toBe('Test')
+      expect(wrapped.features[2]?.properties?.population).toBe(1000000)
+      expect(wrapped.features[2]?.properties?.capital).toBe(true)
+      expect(wrapped.features[2]?.properties?.isWestCopy).toBe(true)
+    })
+
+    it('should handle empty FeatureCollection', () => {
+      const emptyCollection: FeatureCollection = {
+        type: 'FeatureCollection',
+        features: [],
+      }
+
+      const wrapped = createWorldWrappedCollection(emptyCollection)
+
+      expect(wrapped.features).toHaveLength(0)
+    })
+  })
+})

--- a/src/utils/geo/worldWrapping.ts
+++ b/src/utils/geo/worldWrapping.ts
@@ -1,0 +1,88 @@
+import type { FeatureCollection, Feature, Geometry, GeoJsonProperties } from 'geojson'
+import { shiftFeatureCoordinates } from './coordinateTransforms'
+
+export interface WorldWrappingOptions {
+  /**
+   * Whether to mark copied features with isEastCopy/isWestCopy properties
+   * @default true
+   */
+  markCopies?: boolean
+}
+
+/**
+ * Creates a world-wrapped GeoJSON FeatureCollection by duplicating features
+ * at -360° and +360° longitude offsets for seamless horizontal panning.
+ *
+ * This is useful for world maps where users can pan infinitely left or right.
+ *
+ * @param data The original FeatureCollection
+ * @param options Configuration options
+ * @returns A new FeatureCollection with original features plus east/west copies
+ */
+export function createWorldWrappedCollection<
+  T extends Geometry = Geometry,
+  P extends GeoJsonProperties = GeoJsonProperties
+>(
+  data: FeatureCollection<T, P>,
+  options: WorldWrappingOptions = {}
+): FeatureCollection<T, P> {
+  const { markCopies = true } = options
+
+  const wrappedCollection = structuredClone(data)
+  const originalFeatures = data.features
+
+  // Create east copies (shifted +360° longitude)
+  const eastFeatures = originalFeatures.map((feature) => {
+    const clone = shiftFeatureCoordinates(feature, 360) as Feature<T, P>
+    if (markCopies && clone.properties) {
+      ;(clone.properties as any).isEastCopy = true
+    }
+    return clone
+  })
+
+  // Create west copies (shifted -360° longitude)
+  const westFeatures = originalFeatures.map((feature) => {
+    const clone = shiftFeatureCoordinates(feature, -360) as Feature<T, P>
+    if (markCopies && clone.properties) {
+      ;(clone.properties as any).isWestCopy = true
+    }
+    return clone
+  })
+
+  // Combine: original + east + west
+  wrappedCollection.features = [...originalFeatures, ...eastFeatures, ...westFeatures]
+
+  return wrappedCollection
+}
+
+/**
+ * Legacy function for backward compatibility with Vue components
+ * Uses shiftCoordinatesLegacy for in-place mutation
+ */
+export function createWorldWrappedCollectionLegacy<T extends Geometry = Geometry, P = any>(
+  data: FeatureCollection<T, P>,
+  shiftCoordinatesFn: (feature: any, offset: number) => any
+): FeatureCollection<T, P> {
+  const wrappedCollection = structuredClone(data)
+  const originalFeatures = data.features
+
+  const eastFeatures = originalFeatures.map((feature) => {
+    const clone = structuredClone(feature)
+    if (!clone.properties) clone.properties = { name: '' } as P
+    ;(clone.properties as any).isEastCopy = true
+    shiftCoordinatesFn(clone, 360)
+    return clone
+  })
+
+  const westFeatures = originalFeatures.map((feature) => {
+    const clone = structuredClone(feature)
+    if (!clone.properties) clone.properties = { name: '' } as P
+    ;(clone.properties as any).isWestCopy = true
+    shiftCoordinatesFn(clone, -360)
+    return clone
+  })
+
+  wrappedCollection.features = [...originalFeatures, ...eastFeatures, ...westFeatures]
+
+  return wrappedCollection
+}


### PR DESCRIPTION
## Summary
This PR extracts duplicated world wrapping logic into a centralized utility module, eliminating code duplication and providing a clean API for creating world-wrapped GeoJSON collections.

**Changes:**
- Created `src/utils/geo/worldWrapping.ts` with world wrapping functions:
  - `createWorldWrappedCollection()`: Creates east/west copies at ±360° for seamless panning
  - `createWorldWrappedCollectionLegacy()`: Backward-compatible version for migration
  - Configurable options (markCopies flag)

- Added comprehensive test suite with 7 tests covering:
  - East and west copy creation
  - Coordinate shifting verification
  - Immutability (original collection unchanged)
  - Multiple features handling
  - Different geometry types (Point, Polygon)
  - Property preservation
  - Optional copy marking

**Code Reduction:**
- Removed ~50 lines of duplicated code from:
  - `WorldCountries.vue`: Replaced local processGeojsonData with utility call
  - `FrenchDepartments.vue`: Replaced local processGeojsonData with utility call

**Verification:**
```bash
bun run test         # All 40 tests passing
bun run type-check   # Type checking passes
```

**Benefits:**
- Single source of truth for world wrapping
- Reusable across all map-based games
- Type-safe with proper GeoJSON types
- Comprehensive test coverage
- Clean, declarative API

**Related Issue:**
Part of #32 - Geography Game Modernization Plan (Phase 1, PR 4/7)