### PR TITLE
MOD-2.5: Game JSON Configurations

### DIFF
--- a/src/config/games/cities/london-boroughs.json
+++ b/src/config/games/cities/london-boroughs.json
@@ -1,0 +1,25 @@
+{
+  "id": "london-boroughs",
+  "name": "London Boroughs",
+  "category": "cities",
+  "route": "/game/london-boroughs",
+  "icon": "mdi-castle",
+  "emoji": "🏰",
+  "color": "indigo-darken-1",
+  "description": "Identify all 32 boroughs of Greater London",
+  "tags": ["london", "uk", "europe", "easy"],
+  "difficulty": 1,
+  "featured": true,
+  "estimatedTime": 6,
+  "config": {
+    "dataUrl": "https://gis2.london.gov.uk/server/rest/services/apps/webmap_context_layer/MapServer/3/query?outFields=*&where=1%3D1&f=geojson",
+    "mapCenter": [51.5074, -0.1278],
+    "zoom": 10,
+    "maxBounds": [
+      [51.2868, -0.5103],
+      [51.6918, 0.3340]
+    ],
+    "propertyName": "name",
+    "targetLabel": "Borough"
+  }
+}

--- a/src/config/games/cities/paris-arrondissements.json
+++ b/src/config/games/cities/paris-arrondissements.json
@@ -1,0 +1,25 @@
+{
+  "id": "paris-arrondissements",
+  "name": "Paris Arrondissements",
+  "category": "cities",
+  "route": "/game/paris-arrondissements",
+  "icon": "mdi-eiffel-tower",
+  "emoji": "🗼",
+  "color": "purple-darken-1",
+  "description": "Identify all 20 arrondissements of Paris",
+  "tags": ["paris", "france", "europe", "easy"],
+  "difficulty": 1,
+  "featured": true,
+  "estimatedTime": 5,
+  "config": {
+    "dataUrl": "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/arrondissements/exports/geojson",
+    "mapCenter": [48.8566, 2.3522],
+    "zoom": 11,
+    "maxBounds": [
+      [48.8155, 2.2241],
+      [48.9021, 2.4699]
+    ],
+    "propertyName": "c_ar",
+    "targetLabel": "Arrondissement"
+  }
+}

--- a/src/config/games/countries/europe.json
+++ b/src/config/games/countries/europe.json
@@ -1,0 +1,22 @@
+{
+  "id": "europe-countries",
+  "name": "European Countries",
+  "category": "countries",
+  "route": "/game/europe-countries",
+  "icon": "mdi-map-marker",
+  "emoji": "🇪🇺",
+  "color": "green-darken-1",
+  "description": "Identify all countries in Europe",
+  "tags": ["europe", "countries", "geography", "medium"],
+  "difficulty": 2,
+  "featured": true,
+  "estimatedTime": 10,
+  "config": {
+    "dataUrl": "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_countries.geojson",
+    "mapCenter": [55, 15],
+    "zoom": 4,
+    "propertyName": "name",
+    "targetLabel": "Country",
+    "processors": ["filterEurope"]
+  }
+}

--- a/src/config/games/countries/world.json
+++ b/src/config/games/countries/world.json
@@ -1,0 +1,23 @@
+{
+  "id": "world-countries",
+  "name": "World Countries",
+  "category": "countries",
+  "route": "/game/world-countries",
+  "icon": "mdi-earth",
+  "emoji": "🌍",
+  "color": "blue-darken-1",
+  "description": "Identify all countries in the world",
+  "tags": ["world", "countries", "geography", "hard"],
+  "difficulty": 4,
+  "featured": true,
+  "estimatedTime": 30,
+  "config": {
+    "dataUrl": "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_countries.geojson",
+    "mapCenter": [20, 0],
+    "zoom": 2,
+    "propertyName": "name",
+    "targetLabel": "Country",
+    "totalRounds": 241,
+    "processors": ["worldWrapping"]
+  }
+}

--- a/src/config/games/divisions/us-states.json
+++ b/src/config/games/divisions/us-states.json
@@ -1,0 +1,25 @@
+{
+  "id": "us-states",
+  "name": "US States",
+  "category": "divisions",
+  "route": "/game/us-states",
+  "icon": "mdi-flag-variant",
+  "emoji": "🇺🇸",
+  "color": "red-darken-1",
+  "description": "Identify all 50 states of the United States",
+  "tags": ["usa", "states", "north-america", "easy"],
+  "difficulty": 2,
+  "featured": true,
+  "estimatedTime": 8,
+  "config": {
+    "dataUrl": "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_110m_admin_1_states_provinces_shp.geojson",
+    "mapCenter": [39.8283, -98.5795],
+    "zoom": 4,
+    "maxBounds": [
+      [18, -130],
+      [50, -65]
+    ],
+    "propertyName": "name",
+    "targetLabel": "State"
+  }
+}

--- a/src/config/games/games.spec.ts
+++ b/src/config/games/games.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { validateGameDefinition } from "../../schemas/gameConfig.schema";
+import worldCountries from "./countries/world.json";
+import europeCountries from "./countries/europe.json";
+import usStates from "./divisions/us-states.json";
+import parisArrondissements from "./cities/paris-arrondissements.json";
+import londonBoroughs from "./cities/london-boroughs.json";
+
+describe("Game JSON Configurations", () => {
+  describe("World Countries", () => {
+    it("should be valid against schema", () => {
+      const errors = validateGameDefinition(worldCountries);
+      expect(errors).toEqual([]);
+    });
+
+    it("should have correct id", () => {
+      expect(worldCountries.id).toBe("world-countries");
+    });
+
+    it("should have correct category", () => {
+      expect(worldCountries.category).toBe("countries");
+    });
+
+    it("should have world wrapping processor", () => {
+      expect(worldCountries.config.processors).toContain("worldWrapping");
+    });
+  });
+
+  describe("Europe Countries", () => {
+    it("should be valid against schema", () => {
+      const errors = validateGameDefinition(europeCountries);
+      expect(errors).toEqual([]);
+    });
+
+    it("should have correct id", () => {
+      expect(europeCountries.id).toBe("europe-countries");
+    });
+
+    it("should have Europe filter processor", () => {
+      expect(europeCountries.config.processors).toContain("filterEurope");
+    });
+  });
+
+  describe("US States", () => {
+    it("should be valid against schema", () => {
+      const errors = validateGameDefinition(usStates);
+      expect(errors).toEqual([]);
+    });
+
+    it("should have correct id", () => {
+      expect(usStates.id).toBe("us-states");
+    });
+
+    it("should have correct category", () => {
+      expect(usStates.category).toBe("divisions");
+    });
+
+    it("should have map bounds", () => {
+      expect(usStates.config.maxBounds).toBeDefined();
+    });
+  });
+
+  describe("Paris Arrondissements", () => {
+    it("should be valid against schema", () => {
+      const errors = validateGameDefinition(parisArrondissements);
+      expect(errors).toEqual([]);
+    });
+
+    it("should have correct id", () => {
+      expect(parisArrondissements.id).toBe("paris-arrondissements");
+    });
+
+    it("should have correct category", () => {
+      expect(parisArrondissements.category).toBe("cities");
+    });
+
+    it("should have correct property name", () => {
+      expect(parisArrondissements.config.propertyName).toBe("c_ar");
+    });
+  });
+
+  describe("London Boroughs", () => {
+    it("should be valid against schema", () => {
+      const errors = validateGameDefinition(londonBoroughs);
+      expect(errors).toEqual([]);
+    });
+
+    it("should have correct id", () => {
+      expect(londonBoroughs.id).toBe("london-boroughs");
+    });
+
+    it("should have correct category", () => {
+      expect(londonBoroughs.category).toBe("cities");
+    });
+
+    it("should have map bounds", () => {
+      expect(londonBoroughs.config.maxBounds).toBeDefined();
+    });
+  });
+
+  describe("All Games", () => {
+    const allGames = [
+      worldCountries,
+      europeCountries,
+      usStates,
+      parisArrondissements,
+      londonBoroughs,
+    ];
+
+    it("should have unique IDs", () => {
+      const ids = allGames.map((game) => game.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    it("should have unique routes", () => {
+      const routes = allGames.map((game) => game.route);
+      const uniqueRoutes = new Set(routes);
+      expect(uniqueRoutes.size).toBe(routes.length);
+    });
+
+    it("should all be featured", () => {
+      allGames.forEach((game) => {
+        expect(game.featured).toBe(true);
+      });
+    });
+
+    it("should all have difficulty levels", () => {
+      allGames.forEach((game) => {
+        expect(game.difficulty).toBeGreaterThanOrEqual(1);
+        expect(game.difficulty).toBeLessThanOrEqual(5);
+      });
+    });
+
+    it("should all have valid routes", () => {
+      allGames.forEach((game) => {
+        expect(game.route).toMatch(/^\/game\/[a-z0-9-]+$/);
+      });
+    });
+  });
+});

--- a/src/schemas/gameConfig.schema.ts
+++ b/src/schemas/gameConfig.schema.ts
@@ -126,6 +126,19 @@ export const GAME_CONFIG_SCHEMA = {
           description: "Label for the target entity",
           examples: ["Country", "State", "District"],
         },
+        totalRounds: {
+          type: "integer",
+          minimum: 1,
+          description: "Total number of rounds for the game",
+        },
+        processors: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description: "List of processor names to apply to GeoJSON data",
+          examples: [["worldWrapping"], ["filterEurope", "worldWrapping"]],
+        },
       },
       additionalProperties: true,
       description: "Game configuration object",

--- a/src/types/game.d.ts
+++ b/src/types/game.d.ts
@@ -1,11 +1,12 @@
 import L from "leaflet";
 import type { GeoJsonObject, Feature, GeoJsonProperties } from "geojson";
+import type { ProcessorName, GeoJSONProcessor } from "../utils/geo/processors";
 
 export interface GameConfig {
   /**
    * Name of the game (e.g., "US States")
    */
-  name: string;
+  name?: string;
 
   /**
    * URL to fetch the GeoJSON data
@@ -44,8 +45,20 @@ export interface GameConfig {
 
   /**
    * Maximum number of rounds (defaults to all available entities)
+   * @deprecated Use totalRounds instead
    */
   maxRounds?: number;
+
+  /**
+   * Total number of rounds for the game (defaults to all available entities)
+   */
+  totalRounds?: number;
+
+  /**
+   * Optional processors to apply to GeoJSON data
+   * Can be processor names from registry or custom processor functions
+   */
+  processors?: (ProcessorName | GeoJSONProcessor)[];
 
   /**
    * Optional fallback list of entity names if filtering returns no results


### PR DESCRIPTION
## Summary

Creates JSON configuration files for 5 pilot games (PR #44, task MOD-2.5 from modernization plan).

## Changes

### Game Configurations (5 files)
- **`src/config/games/countries/world.json`** - World Countries with worldWrapping processor
- **`src/config/games/countries/europe.json`** - European Countries with filterEurope processor
- **`src/config/games/divisions/us-states.json`** - US States with map bounds
- **`src/config/games/cities/paris-arrondissements.json`** - Paris Arrondissements  
- **`src/config/games/cities/london-boroughs.json`** - London Boroughs

### Type Extensions
- **`src/types/game.d.ts`** - Extended GameConfig interface:
  - Added `totalRounds?: number` for game round limits
  - Added `processors?: (ProcessorName | GeoJSONProcessor)[]` for GeoJSON transforms
  - Made `name?: string` optional (inherits from GameDefinition.name)
  - Deprecated `maxRounds` in favor of `totalRounds`

- **`src/schemas/gameConfig.schema.ts`** - Updated JSON schema:
  - Added `totalRounds` field validation
  - Added `processors` array validation

### Tests
- **`src/config/games/games.spec.ts`** (24 tests)
  - Schema validation for all 5 games
  - ID and route uniqueness
  - Difficulty level validation
  - Processor configuration checks

## Configuration Details

| Game | ID | Category | Processors | Difficulty | Rounds |
|------|-----|----------|------------|------------|--------|
| World Countries | world-countries | countries | worldWrapping | 4 | 241 |
| Europe Countries | europe-countries | countries | filterEurope | 2 | - |
| US States | us-states | divisions | - | 2 | - |
| Paris Arrondissements | paris-arrondissements | cities | - | 1 | - |
| London Boroughs | london-boroughs | cities | - | 1 | - |

## Processor Integration

**World Countries:**
```json
"processors": ["worldWrapping"]
```
Creates wrapped world copies at ±360° for seamless panning.

**Europe Countries:**
```json
"processors": ["filterEurope"]
```
Filters to 46 European countries from world dataset.

## Test Results

- **24 new tests** passing
- **199 total tests** (175 previous + 24 new)
- All configs validate against JSON schema
- Unique IDs and routes verified

## Next Steps (MOD-2.6)

- Create game registry loader
- Load JSON configs into registry
- Add dynamic route for `/game/:gameId`

## Related

- Part of Phase 2: Game Registry System
- Builds on #40 (types), #41 (processors), #42 (composable), #43 (GameView)
- Configs ready but not yet loaded into registry