### PR TITLE
MOD-2.9: Migrate Continent Games to JSON Registry

### DIFF
--- a/src/config/games/countries/africa.json
+++ b/src/config/games/countries/africa.json
@@ -1,0 +1,23 @@
+{
+  "id": "africa-countries",
+  "name": "African Countries",
+  "category": "countries",
+  "route": "/game/africa-countries",
+  "icon": "mdi-earth",
+  "emoji": "🌍",
+  "color": "green-darken-2",
+  "description": "Identify all countries in Africa",
+  "tags": ["africa", "countries", "geography", "continent"],
+  "difficulty": 3,
+  "featured": true,
+  "estimatedTime": 12,
+  "config": {
+    "dataUrl": "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_countries.geojson",
+    "mapCenter": [5, 20],
+    "zoom": 3,
+    "propertyName": "name",
+    "targetLabel": "Country",
+    "totalRounds": 54,
+    "processors": ["filterAfrica"]
+  }
+}

--- a/src/config/games/countries/asia.json
+++ b/src/config/games/countries/asia.json
@@ -1,0 +1,22 @@
+{
+  "id": "asia-countries",
+  "name": "Asian Countries",
+  "category": "countries",
+  "route": "/game/asia-countries",
+  "icon": "mdi-earth",
+  "emoji": "🌏",
+  "color": "red-darken-2",
+  "description": "Identify all countries in Asia, including Russia",
+  "tags": ["asia", "countries", "geography", "continent"],
+  "difficulty": 3,
+  "featured": true,
+  "estimatedTime": 15,
+  "config": {
+    "dataUrl": "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_countries.geojson",
+    "mapCenter": [35, 90],
+    "zoom": 3,
+    "propertyName": "name",
+    "targetLabel": "Country",
+    "processors": ["filterAsia"]
+  }
+}

--- a/src/config/games/countries/north-america.json
+++ b/src/config/games/countries/north-america.json
@@ -1,0 +1,22 @@
+{
+  "id": "north-america-countries",
+  "name": "North American Countries",
+  "category": "countries",
+  "route": "/game/north-america-countries",
+  "icon": "mdi-earth",
+  "emoji": "🌎",
+  "color": "orange-darken-2",
+  "description": "Identify all countries in North America, including Central America and the Caribbean",
+  "tags": ["north-america", "countries", "geography", "continent"],
+  "difficulty": 2,
+  "featured": true,
+  "estimatedTime": 8,
+  "config": {
+    "dataUrl": "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_countries.geojson",
+    "mapCenter": [25, -90],
+    "zoom": 3,
+    "propertyName": "name",
+    "targetLabel": "Country",
+    "processors": ["filterNorthAmerica"]
+  }
+}

--- a/src/config/games/countries/oceania.json
+++ b/src/config/games/countries/oceania.json
@@ -1,0 +1,23 @@
+{
+  "id": "oceania-countries",
+  "name": "Oceanian Countries",
+  "category": "countries",
+  "route": "/game/oceania-countries",
+  "icon": "mdi-earth",
+  "emoji": "🌏",
+  "color": "purple-darken-2",
+  "description": "Identify all countries in Oceania, including Australia and Pacific island nations",
+  "tags": ["oceania", "countries", "geography", "continent", "pacific"],
+  "difficulty": 2,
+  "featured": true,
+  "estimatedTime": 7,
+  "config": {
+    "dataUrl": "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_countries.geojson",
+    "mapCenter": [-15, -160],
+    "zoom": 3,
+    "propertyName": "name",
+    "targetLabel": "Country",
+    "totalRounds": 25,
+    "processors": ["filterOceania"]
+  }
+}

--- a/src/config/games/countries/south-america.json
+++ b/src/config/games/countries/south-america.json
@@ -1,0 +1,22 @@
+{
+  "id": "south-america-countries",
+  "name": "South American Countries",
+  "category": "countries",
+  "route": "/game/south-america-countries",
+  "icon": "mdi-earth",
+  "emoji": "🌎",
+  "color": "pink-darken-2",
+  "description": "Identify all countries in South America",
+  "tags": ["south-america", "countries", "geography", "continent"],
+  "difficulty": 1,
+  "featured": true,
+  "estimatedTime": 5,
+  "config": {
+    "dataUrl": "https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_countries.geojson",
+    "mapCenter": [-20, -60],
+    "zoom": 3,
+    "propertyName": "name",
+    "targetLabel": "Country",
+    "processors": ["filterSouthAmerica"]
+  }
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,18 +1,11 @@
 import { createRouter, createWebHistory, type NavigationGuardNext, type RouteLocationNormalized } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
-import WorldCountries from '../components/WorldCountries/WorldCountries.vue'
-import AfricanCountries from '../components/WorldCountries/AfricanCountries.vue'
 import UsStates from '../components/AdministrativeDivisions/UsStates.vue'
 import CanadianProvinces from '../components/AdministrativeDivisions/CanadianProvinces.vue'
 import FrenchDepartments from '../components/AdministrativeDivisions/FrenchDepartments.vue'
 import SpanishCommunities from '../components/AdministrativeDivisions/SpanishCommunities.vue'
 import FlagGame from '@/components/FlagGame.vue'
 import WorldCapitals from '../views/WorldCapitals.vue'
-import EuropeMapGame from '../components/WorldCountries/EuropeMapGame.vue'
-import AsiaMapGame from '../components/WorldCountries/AsiaMapGame.vue'
-import NorthAmericaMapGame from '../components/WorldCountries/NorthAmericaMapGame.vue'
-import SouthAmericaMapGame from '../components/WorldCountries/SouthAmericaMapGame.vue'
-import OceaniaMapGame from '../components/WorldCountries/OceaniaMapGame.vue'
 import BrazilianStates from '../components/AdministrativeDivisions/BrazilianStates.vue'
 import AustralianStates from '../components/AdministrativeDivisions/AustralianStates.vue'
 import GermanStates from '../components/AdministrativeDivisions/GermanStates.vue'
@@ -24,10 +17,8 @@ import ChineseProvinces from '../components/AdministrativeDivisions/ChineseProvi
 import BelgianProvinces from '../components/AdministrativeDivisions/BelgianProvinces.vue'
 import DutchProvinces from '../components/AdministrativeDivisions/DutchProvinces.vue'
 import DashboardView from '../views/DashboardView.vue'
-import ParisArrondissements from '../components/CityDistricts/ParisArrondissements.vue'
 import ParisQuartiers from '../components/CityDistricts/ParisQuartiers.vue'
 import ParisDistricts from '../components/CityDistricts/ParisDistricts.vue'
-import LondonBoroughs from '../components/CityDistricts/LondonBoroughs.vue'
 import BarcelonaDistricts from '../components/CityDistricts/BarcelonaDistricts.vue'
 import BarcelonaBarrios from '../components/CityDistricts/BarcelonaBarrios.vue'
 import BordeauxQuartiers from '../components/CityDistricts/BordeauxQuartiers.vue'
@@ -43,19 +34,20 @@ const router = createRouter({
     // Dynamic game route (new system)
     { path: '/game/:gameId', name: 'game', component: GameView },
 
-    // Redirects from legacy routes to new dynamic routes (pilot games)
+    // Redirects from legacy routes to new dynamic routes
     { path: '/world-countries', redirect: '/game/world-countries' },
     { path: '/european-countries', redirect: '/game/europe-countries' },
+    { path: '/african-countries', redirect: '/game/africa-countries' },
+    { path: '/asian-countries', redirect: '/game/asia-countries' },
+    { path: '/north-american-countries', redirect: '/game/north-america-countries' },
+    { path: '/south-american-countries', redirect: '/game/south-america-countries' },
+    { path: '/oceanian-countries', redirect: '/game/oceania-countries' },
     { path: '/us-states', redirect: '/game/us-states' },
     { path: '/paris-arrondissements', redirect: '/game/paris-arrondissements' },
     { path: '/london-boroughs', redirect: '/game/london-boroughs' },
 
     // Legacy routes (keep temporarily until all games migrated)
-    { path: '/african-countries', name: 'african-countries', component: AfricanCountries },
-    { path: '/asian-countries', name: 'asian-countries', component: AsiaMapGame },
-    { path: '/north-american-countries', name: 'north-american-countries', component: NorthAmericaMapGame },
-    { path: '/south-american-countries', name: 'south-american-countries', component: SouthAmericaMapGame },
-    { path: '/oceanian-countries', name: 'oceanian-countries', component: OceaniaMapGame },
+    // Continent games migrated to registry - redirects above
     { path: '/russian-oblasts', name: 'russian-oblasts', component: RussianOblasts },
     { path: '/ukrainian-oblasts', name: 'ukrainian-oblasts', component: UkrainianOblasts },
     { path: '/chinese-provinces', name: 'chinese-provinces', component: ChineseProvinces },

--- a/src/utils/gameLoader.spec.ts
+++ b/src/utils/gameLoader.spec.ts
@@ -18,26 +18,33 @@ describe("gameLoader", () => {
   });
 
   describe("loadGames", () => {
-    it("should call registerGames with pilot games", () => {
+    it("should call registerGames with all games", () => {
       loadGames();
 
       expect(mockRegistry.registerGames).toHaveBeenCalledTimes(1);
       expect(mockRegistry.registerGames).toHaveBeenCalledWith(
         expect.arrayContaining([
+          // Pilot games
           expect.objectContaining({ id: "world-countries" }),
           expect.objectContaining({ id: "europe-countries" }),
           expect.objectContaining({ id: "us-states" }),
           expect.objectContaining({ id: "paris-arrondissements" }),
           expect.objectContaining({ id: "london-boroughs" }),
+          // Continent games
+          expect.objectContaining({ id: "africa-countries" }),
+          expect.objectContaining({ id: "asia-countries" }),
+          expect.objectContaining({ id: "north-america-countries" }),
+          expect.objectContaining({ id: "south-america-countries" }),
+          expect.objectContaining({ id: "oceania-countries" }),
         ])
       );
     });
 
-    it("should load exactly 5 pilot games", () => {
+    it("should load all 10 games (5 pilot + 5 continent)", () => {
       loadGames();
 
       const callArg = mockRegistry.registerGames.mock.calls[0][0];
-      expect(callArg).toHaveLength(5);
+      expect(callArg).toHaveLength(10);
     });
   });
 
@@ -135,13 +142,8 @@ describe("gameLoader", () => {
   });
 
   describe("getGameCount", () => {
-    it("should return 5", () => {
-      expect(getGameCount()).toBe(5);
-    });
-
-    it("should match pilot games length", () => {
-      const games = getPilotGames();
-      expect(getGameCount()).toBe(games.length);
+    it("should return 10 (all games)", () => {
+      expect(getGameCount()).toBe(10);
     });
   });
 });

--- a/src/utils/gameLoader.ts
+++ b/src/utils/gameLoader.ts
@@ -6,16 +6,25 @@
 import { useGameRegistry } from "../composables/useGameRegistry";
 import type { GameDefinition } from "../types/gameRegistry";
 
-// Import pilot game configurations
+// Import game configurations
+// Countries
 import worldCountries from "../config/games/countries/world.json";
 import europeCountries from "../config/games/countries/europe.json";
+import africaCountries from "../config/games/countries/africa.json";
+import asiaCountries from "../config/games/countries/asia.json";
+import northAmericaCountries from "../config/games/countries/north-america.json";
+import southAmericaCountries from "../config/games/countries/south-america.json";
+import oceaniaCountries from "../config/games/countries/oceania.json";
+
+// Divisions
 import usStates from "../config/games/divisions/us-states.json";
+
+// Cities
 import parisArrondissements from "../config/games/cities/paris-arrondissements.json";
 import londonBoroughs from "../config/games/cities/london-boroughs.json";
 
 /**
- * All available game configurations
- * Currently includes 5 pilot games
+ * Pilot game configurations (original 5 games)
  */
 const PILOT_GAMES: GameDefinition[] = [
   worldCountries,
@@ -26,12 +35,36 @@ const PILOT_GAMES: GameDefinition[] = [
 ] as GameDefinition[];
 
 /**
+ * All available game configurations
+ * Currently includes pilot games + continent games
+ */
+const ALL_GAMES: GameDefinition[] = [
+  // World
+  worldCountries,
+
+  // Continents
+  europeCountries,
+  africaCountries,
+  asiaCountries,
+  northAmericaCountries,
+  southAmericaCountries,
+  oceaniaCountries,
+
+  // Divisions
+  usStates,
+
+  // Cities
+  parisArrondissements,
+  londonBoroughs,
+] as GameDefinition[];
+
+/**
  * Load and register all games into the registry
  * Call this once at app startup
  */
 export function loadGames(): void {
   const registry = useGameRegistry();
-  registry.registerGames(PILOT_GAMES);
+  registry.registerGames(ALL_GAMES);
 }
 
 /**
@@ -43,8 +76,16 @@ export function getPilotGames(): readonly GameDefinition[] {
 }
 
 /**
+ * Get list of all games without loading into registry
+ * Useful for testing
+ */
+export function getAllGames(): readonly GameDefinition[] {
+  return ALL_GAMES;
+}
+
+/**
  * Get count of available games
  */
 export function getGameCount(): number {
-  return PILOT_GAMES.length;
+  return ALL_GAMES.length;
 }


### PR DESCRIPTION
## Summary

Migrates all 5 continent-based country games from legacy Vue components to the new JSON registry system, doubling the total games from 5 to 10.

## New Game Configurations

### Africa Countries
- **File:** `src/config/games/countries/africa.json`
- **Countries:** 54 African countries
- **Difficulty:** 3 (Hard)
- **Map Center:** [5, 20]
- **Processor:** `filterAfrica`

### Asia Countries
- **File:** `src/config/games/countries/asia.json`
- **Countries:** ~45 Asian countries (including Russia)
- **Difficulty:** 3 (Hard)
- **Map Center:** [35, 90]
- **Processor:** `filterAsia`

### North America Countries
- **File:** `src/config/games/countries/north-america.json`
- **Countries:** ~23 countries (including Central America & Caribbean)
- **Difficulty:** 2 (Medium)
- **Map Center:** [25, -90]
- **Processor:** `filterNorthAmerica`

### South America Countries
- **File:** `src/config/games/countries/south-america.json`
- **Countries:** 12 South American countries
- **Difficulty:** 1 (Easy)
- **Map Center:** [-20, -60]
- **Processor:** `filterSouthAmerica`

### Oceania Countries
- **File:** `src/config/games/countries/oceania.json`
- **Countries:** 14 Oceanian countries
- **Total Rounds:** 25
- **Difficulty:** 2 (Medium)
- **Map Center:** [-15, -160]
- **Processor:** `filterOceania`

## Changes

### Router Updates (`src/router/index.ts`)
**Added Redirects:**
```javascript
{ path: '/african-countries', redirect: '/game/africa-countries' },
{ path: '/asian-countries', redirect: '/game/asia-countries' },
{ path: '/north-american-countries', redirect: '/game/north-america-countries' },
{ path: '/south-american-countries', redirect: '/game/south-america-countries' },
{ path: '/oceanian-countries', redirect: '/game/oceania-countries' },
```

**Removed:**
- Duplicate legacy route definitions
- Unused component imports (AfricanCountries, AsiaMapGame, etc.)

### Game Loader Updates (`src/utils/gameLoader.ts`)
**Added:**
- `ALL_GAMES` constant with all 10 games
- `getAllGames()` function for testing

**Updated:**
- `loadGames()` now registers `ALL_GAMES` instead of `PILOT_GAMES`
- `getGameCount()` returns total count (10 instead of 5)
- Maintained `getPilotGames()` for backward compatibility

### Test Updates
**Updated:** `src/utils/gameLoader.spec.ts`
- Expects 10 games instead of 5
- Tests all continent games are loaded
- All 13 tests passing ✅

## Processors

All continent filter processors were **already implemented** in the processor registry (`src/utils/geo/processors/index.ts`):
- ✅ `filterAfrica` - Filters to 54 African countries
- ✅ `filterAsia` - Filters to Asian countries (includes Russia)
- ✅ `filterNorthAmerica` - Filters to North American countries
- ✅ `filterSouthAmerica` - Filters to 12 South American countries
- ✅ `filterOceania` - Filters to 14 Oceanian countries

## Legacy Component Migration

**Components Removed from Router (now via registry):**
- ❌ `AfricanCountries.vue`
- ❌ `AsiaMapGame.vue`
- ❌ `NorthAmericaMapGame.vue`
- ❌ `SouthAmericaMapGame.vue`
- ❌ `OceaniaMapGame.vue`

**Note:** Component files still exist in codebase but are no longer used. Will be deleted in cleanup PR.

## Game Count Summary

**Total Games:** 10
- 1 World map (all countries)
- 6 Continent maps (Europe, Africa, Asia, North America, South America, Oceania)
- 1 US States
- 2 City districts (Paris, London)

**Pilot Games (original 5):** Still identified separately for testing
**New Games (this PR):** 5 continent games

## Testing

### Unit Tests
```bash
bun test src/utils/gameLoader.spec.ts
```
**Result:** 13/13 tests passing ✅

### Game Configuration Validation
```bash
bun test src/config/games/games.spec.ts
```
**Result:** 24/24 tests passing ✅

### E2E Tests
All games accessible via:
- Direct routes: `/game/{game-id}`
- Legacy redirects: `/african-countries`, etc.

## Migration Safety

### Risk Level: ✅ **LOW**

**Rationale:**
1. ✅ Same pattern as validated pilot games
2. ✅ All processors pre-existing and tested
3. ✅ Legacy routes redirect correctly
4. ✅ No breaking changes
5. ✅ Component files untouched (can rollback easily)

### Backward Compatibility
- ✅ Legacy routes redirect to new system
- ✅ Old component imports removed from router only
- ✅ Component files still exist (not deleted)

## Next Steps

After this PR:
- PR #49: Migrate remaining division games (14 games)
- PR #50: Migrate remaining city games (5 games)
- PR #51: Remove old game components and cleanup

## Related

- Part of Phase 2: Game Registry System (#32)
- Depends on: PR #47 (E2E Tests & Validation)
- Follows: PR_STRATEGY.md lines 970-1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)