### PR TITLE
feat: Automate totalRounds calculation in build process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@ bun run type-check  # Run TypeScript type checker (vue-tsc)
 bun run lint        # Run ESLint with auto-fix
 ```
 
+### Maintenance & Scripts
+```bash
+bun run update-total-rounds  # Update totalRounds in all game configs
+```
+
+**Note:** The `totalRounds` field in game configs is automatically updated before each build via the `prebuild` script. The script extracts entity counts from test files and updates the JSON configs accordingly. This ensures `totalRounds` stays in sync with actual GeoJSON data without manual counting.
+
 ## Architecture
 
 ### Core Game System

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "packageManager": "bun@1.1.43",
   "scripts": {
     "dev": "vite",
+    "prebuild": "tsx scripts/add-total-rounds.ts",
     "build": "vite build",
     "preview": "vite preview",
     "build-only": "vite build",
@@ -17,6 +18,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
+    "update-total-rounds": "tsx scripts/add-total-rounds.ts",
     "start": "vite preview --host --port $PORT"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Automated `totalRounds` calculation to run before every production build
- Eliminates manual counting of GeoJSON features
- Reduces human error and keeps configs in sync with test data

## Changes

### package.json
- **Added `prebuild` script**: Runs `scripts/add-total-rounds.ts` automatically before `build`
- **Added `update-total-rounds` script**: Manual script for developers to update configs

### CLAUDE.md
- Added "Maintenance & Scripts" section documenting the automation
- Explains how totalRounds is kept in sync automatically

## How It Works

The `scripts/add-total-rounds.ts` script:
1. Finds all game config test files (`*.test.ts`)
2. Extracts entity count from: `expect(uniqueEntities).toHaveLength(NUMBER)`
3. Updates corresponding JSON config with `totalRounds: NUMBER`
4. Runs automatically on `bun run build`

## Benefits
- ✅ No more manual feature counting
- ✅ totalRounds always matches actual GeoJSON data
- ✅ Automatic on every build (production)
- ✅ Manual script available for development

## Testing
Tested successfully - all 28 game configs already up to date:
```
✨ Complete! Updated 0 configs, skipped 28 (already up to date)
```

## From Checklist
Completes: "Auto-calculate totalRounds" (Nice to Have #7)