### PR TITLE
refactor: Extract hardcoded Gibraltar coordinates to JSON

### DIFF
--- a/src/data/geography/special-territories.json
+++ b/src/data/geography/special-territories.json
@@ -1,0 +1,25 @@
+{
+  "gibraltar": {
+    "type": "Feature",
+    "properties": {
+      "name": "Gibraltar",
+      "continent": "Europe",
+      "name_long": "Gibraltar",
+      "admin": "United Kingdom"
+    },
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [-5.3536, 36.1086],
+          [-5.3384, 36.1086],
+          [-5.3384, 36.1225],
+          [-5.3438, 36.1449],
+          [-5.3536, 36.1449],
+          [-5.3589, 36.1225],
+          [-5.3536, 36.1086]
+        ]
+      ]
+    }
+  }
+}

--- a/src/utils/geo/processors/index.ts
+++ b/src/utils/geo/processors/index.ts
@@ -1,5 +1,6 @@
 import type { FeatureCollection, Geometry, GeoJsonProperties } from "geojson";
 import { createWorldWrappedCollection } from "../worldWrapping";
+import specialTerritories from "@/data/geography/special-territories.json";
 
 /**
  * Processor function that transforms a GeoJSON FeatureCollection
@@ -82,30 +83,8 @@ export const PROCESSOR_REGISTRY = {
         return polygon.some(ring => ring.some(point => point[1] > SVALBARD_LATITUDE_THRESHOLD));
       };
 
-      // Gibraltar feature (not in Natural Earth data)
-      const gibraltarFeature: any = {
-        type: "Feature",
-        properties: {
-          name: "Gibraltar",
-          continent: "Europe",
-          name_long: "Gibraltar",
-          admin: "United Kingdom",
-        },
-        geometry: {
-          type: "Polygon",
-          coordinates: [
-            [
-              [-5.3536, 36.1086],
-              [-5.3384, 36.1086],
-              [-5.3384, 36.1225],
-              [-5.3438, 36.1449],
-              [-5.3536, 36.1449],
-              [-5.3589, 36.1225],
-              [-5.3536, 36.1086]
-            ]
-          ]
-        }
-      };
+      // Gibraltar feature (from special territories data)
+      const gibraltarFeature: any = specialTerritories.gibraltar;
 
       const cyprusFeature = data.features.find(f => f.properties?.name === "Cyprus");
       const northCyprusFeature = data.features.find(f => f.properties?.name === "N. Cyprus");


### PR DESCRIPTION
## Summary
- Extracted hardcoded Gibraltar geography data to external JSON file
- Improves maintainability and follows data-driven architecture
- Reduces processor code complexity

## Changes

### New File: `src/data/geography/special-territories.json`
Contains Gibraltar GeoJSON feature data that was previously hardcoded:
- Type: Feature
- Geometry: Polygon with 7 coordinates
- Properties: name, continent, name_long, admin

### Modified: `src/utils/geo/processors/index.ts`
- Removed 23 lines of hardcoded Gibraltar coordinates
- Added import of `special-territories.json`
- Simplified Gibraltar feature to: `specialTerritories.gibraltar`

## Benefits
- ✅ Easier to maintain territory data
- ✅ Clear separation of data and logic
- ✅ Future territories can be added to JSON
- ✅ Follows established patterns in codebase
- ✅ -24 lines, +28 lines (net +4, but data is now in proper place)

## Testing
- ✅ All 31 processor tests pass
- ✅ Type checking passes
- ✅ Gibraltar still renders correctly in Europe games

## From Checklist
Completes: "Extract Hardcoded Geography Data" (Nice to Have #8)