### PR TITLE
feat: Add cache warming for featured games on app load

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,9 @@ import { onMounted } from 'vue';
 import { polyfillCountryFlagEmojis } from 'country-flag-emoji-polyfill';
 import Header from './components/AppBar.vue';
 import { loadAllGames } from './utils/gameLazyLoader';
+import { useGameRegistry } from './composables/useGameRegistry';
+import { fetchAndCacheGeoJSON } from './utils/geo/geojsonCache';
+import type { ProcessorName } from './utils/geo/processors/index';
 
 // Apply flag emoji polyfill globally
 polyfillCountryFlagEmojis();
@@ -20,10 +23,39 @@ polyfillCountryFlagEmojis();
 onMounted(async () => {
   try {
     await loadAllGames();
+
+    // Warm cache for featured games after games are loaded
+    warmFeaturedGamesCache();
   } catch (error) {
     console.error('[App] Failed to load games:', error);
   }
 });
+
+/**
+ * Warm cache for featured games in the background
+ * This pre-fetches GeoJSON data for featured games to improve first-load experience
+ */
+function warmFeaturedGamesCache(): void {
+  const registry = useGameRegistry();
+  const featuredGames = registry.featured.value;
+
+  if (featuredGames.length === 0) {
+    return;
+  }
+
+  console.warn(`[App] Warming cache for ${featuredGames.length} featured games...`);
+
+  // Fetch featured game data in background (fire and forget)
+  featuredGames.forEach((game) => {
+    const dataUrl = game.config.dataUrl;
+    const processors = (game.config.processors || []) as ProcessorName[];
+
+    // Silently fetch and cache - don't block or show errors
+    fetchAndCacheGeoJSON(dataUrl, processors).catch(() => {
+      // Silent fail - cache warming is optional optimization
+    });
+  });
+}
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
- Implemented background cache warming for featured games
- Pre-fetches GeoJSON data after app loads to improve first-play experience
- Non-blocking, fire-and-forget pattern with silent failures

## Changes

### Modified: `src/App.vue`
Added `warmFeaturedGamesCache()` function that:
1. Gets all games with `featured: true` from registry
2. Calls `fetchAndCacheGeoJSON()` for each game's dataUrl
3. Applies configured processors
4. Silently fails if fetch errors occur

**Execution:**
- Runs after `loadAllGames()` completes in `onMounted()`
- Background operation - doesn't block UI
- Uses `console.warn()` for visibility (ESLint-compliant)

## Benefits
- ✅ Featured games load instantly on first play
- ✅ No impact on initial app load time (background)
- ✅ Works with existing in-memory cache (30min TTL)
- ✅ Service worker also caches the network requests
- ✅ Improved UX for most popular games

## Technical Details
- Uses existing `fetchAndCacheGeoJSON()` from geojsonCache utility
- Respects LRU cache limits (50 entries, 30min TTL)
- Fire-and-forget - failures don't affect app
- Processors applied as configured per game

## Example
If World Countries and Europe Countries are featured:
1. App loads
2. Games registry initialized
3. Cache warming starts in background
4. GeoJSON for both games fetched and cached
5. User clicks "World Countries" → instant load

## From Checklist
Completes: "Add Cache Warming" (Nice to Have #9)